### PR TITLE
Add output.css to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ npm-debug.log*
 *.pem
 .DS_Store
 Thumbs.db
+
+output.css


### PR DESCRIPTION
Added output.css to the .gitignore file to prevent generated CSS files from being tracked by git.